### PR TITLE
Add a WebSocket plugin

### DIFF
--- a/jetty-console-plugins/jetty-console-websocket-plugin/pom.xml
+++ b/jetty-console-plugins/jetty-console-websocket-plugin/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright 2016 Eduardo Sánchez
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.simplericity.jettyconsole</groupId>
+    <artifactId>jetty-console-plugins</artifactId>
+    <version>1.59-SNAPSHOT</version>
+  </parent>
+  <artifactId>jetty-console-websocket-plugin</artifactId>
+  <name>Jetty Console websocket plugin</name>
+
+  <dependencies>
+  	<dependency>
+  		<groupId>org.eclipse.jetty.websocket</groupId>
+  		<artifactId>javax-websocket-server-impl</artifactId>
+  		<version>${jetty.version}</version>
+  	</dependency>
+  </dependencies>
+</project>

--- a/jetty-console-plugins/jetty-console-websocket-plugin/src/main/java/org/simplericity/jettyconsole/websocket/JettyWebsocketPlugin.java
+++ b/jetty-console-plugins/jetty-console-websocket-plugin/src/main/java/org/simplericity/jettyconsole/websocket/JettyWebsocketPlugin.java
@@ -1,0 +1,24 @@
+package org.simplericity.jettyconsole.websocket;
+
+import javax.servlet.ServletException;
+
+import org.eclipse.jetty.webapp.WebAppContext;
+import org.eclipse.jetty.websocket.jsr356.server.deploy.WebSocketServerContainerInitializer;
+import org.simplericity.jettyconsole.api.JettyConsolePluginBase;
+
+public class JettyWebsocketPlugin extends JettyConsolePluginBase {
+
+	public JettyWebsocketPlugin() {
+		super(JettyWebsocketPlugin.class);
+	}
+
+	@Override
+	public void beforeStart(WebAppContext context) {
+		try {
+			WebSocketServerContainerInitializer.configureContext(context);
+		} catch (ServletException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+}

--- a/jetty-console-plugins/jetty-console-websocket-plugin/src/main/resources/META-INF/services/org.simplericity.jettyconsole.api.JettyConsolePlugin/simple.txt
+++ b/jetty-console-plugins/jetty-console-websocket-plugin/src/main/resources/META-INF/services/org.simplericity.jettyconsole.api.JettyConsolePlugin/simple.txt
@@ -1,0 +1,1 @@
+org.simplericity.jettyconsole.websocket.JettyWebsocketPlugin


### PR DESCRIPTION
To use websockets in jetty using JSR-356 annotations, you need to configure the context and add the relevant jar file. 
