### PR TITLE
Update jetty to 9.4.0.v20161208 (latest version at the moment)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     </dependencies>
 
     <properties>
-        <jetty.version>9.3.6.v20151106</jetty.version>
+        <jetty.version>9.4.0.v20161208</jetty.version>
         <jexmec.version>2.0.0rc7</jexmec.version>
         <slf4j.version>1.7.5</slf4j.version>
     </properties>


### PR DESCRIPTION
Would be nice for this version to eventually be set by the WAR project using this plugin...Thanks for this plugin!