### PR TITLE
Update jetty version number to 9.4.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -184,7 +184,7 @@
     </dependencies>
 
     <properties>
-        <jetty.version>9.4.0.v20161208</jetty.version>
+        <jetty.version>9.4.12.v20180830</jetty.version>
         <jexmec.version>2.0.0rc7</jexmec.version>
         <slf4j.version>1.7.5</slf4j.version>
     </properties>


### PR DESCRIPTION
Jetty 9.4.x versions prior to 9.4.8 are subject to an startup error if any dependencies of a war file being deployed contain `module-info.class` files from Java 9, whether or not the project is using java 9. Information about this issue can be found here:

https://stackoverflow.com/questions/45311295/error-scanning-entry-module-info-class-when-starting-jetty-server

https://github.com/eclipse/jetty.project/issues/1692

Here is an example of the exception:
```
[main] INFO org.eclipse.jetty.server.Server - jetty-9.4.0.v20161208
[main] INFO org.eclipse.jetty.annotations.AnnotationConfiguration - Scanning elapsed time=4857ms
[main] WARN org.eclipse.jetty.webapp.WebAppContext - Failed startup of context o.s.j.JettyConsoleWebappContext@643b1d11{/,file:///private/var/folders/kh/mfmlr7jn1hxcn151fvnhkpg80000gp/T/fcrepo-webapp-5.0.0-SNAPSHOT-jetty-console.jar_8080/webapp/,UNAVAILABLE}{/Users/danny/code/fcrepo4/fcrepo-webapp/target/fcrepo-webapp-5.0.0-SNAPSHOT-jetty-console.jar}
java.lang.RuntimeException: Error scanning entry module-info.class from jar file:///private/var/folders/kh/mfmlr7jn1hxcn151fvnhkpg80000gp/T/fcrepo-webapp-5.0.0-SNAPSHOT-jetty-console.jar_8080/webapp/WEB-INF/lib/asm-all-repackaged-2.5.0-b32.jar
	at org.eclipse.jetty.annotations.AnnotationParser.parseJar(AnnotationParser.java:891)
	at org.eclipse.jetty.annotations.AnnotationParser.parse(AnnotationParser.java:837)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$ParserTask.call(AnnotationConfiguration.java:159)
	at org.eclipse.jetty.annotations.AnnotationConfiguration$1.run(AnnotationConfiguration.java:464)
	at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:672)
	at org.eclipse.jetty.util.thread.QueuedThreadPool$2.run(QueuedThreadPool.java:590)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.IllegalArgumentException
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.objectweb.asm.ClassReader.<init>(Unknown Source)
	at org.eclipse.jetty.annotations.AnnotationParser.scanClass(AnnotationParser.java:959)
	at org.eclipse.jetty.annotations.AnnotationParser.parseJarEntry(AnnotationParser.java:940)
	at org.eclipse.jetty.annotations.AnnotationParser.parseJar(AnnotationParser.java:887)
	... 6 more
```